### PR TITLE
Speed/byte-compiles-apply.analogues.netcdf

### DIFF
--- a/R/CA.R
+++ b/R/CA.R
@@ -127,7 +127,7 @@ apply.analogue <- function(x, weights) {
 # analog.indices: vector of time indices that correspond to the timesteps to compose together
 # weights: vector of length num.analogues corresponding to the analog indices
 # obs.nc: An open netcdf file containing gridded observations
-apply.analogues.netcdf <- function(analog.indices, weights, obs.nc, varid='tasmax') {
+apply.analogues.netcdf.c <- function(analog.indices, weights, obs.nc, varid='tasmax') {
     dims <- c(obs.nc$var[[varid]]$size[1:2],getOption('n.analogues'))
     apply(
         array(
@@ -146,6 +146,8 @@ apply.analogues.netcdf <- function(analog.indices, weights, obs.nc, varid='tasma
         1:2, sum
     )
 }
+
+apply.analogues.netcdf <- compiler::cmpfun(apply.analogues.netcdf.c)
 
 # obs.at.analogues should be a matrix (n.analogues x number of cells)
 # gcm.values should a 1d vector of gcm values for each cell at the given time step


### PR DESCRIPTION
Adds a simple byte compilation function of apply.analogues.netcdf. Results in a ~6% speedup in total time for profiled `tasmax` and `pr`. 

Many other avenues were experimented with, including removing the positive_pr check outside of `mapply` in `apply.analogues.netcdf` with little improvement to performance, so ultimately wasn't used.