### PR TITLE
refactor Climate Analogues to use smaller arrays

### DIFF
--- a/R/CA.R
+++ b/R/CA.R
@@ -215,9 +215,12 @@ find.analogues <- function(gcm, agged.obs, times, now, n.analogues=getOption('n.
     # substract the GCM at this time step from the aggregated obs *for every library time value*
     # square that difference
 
-    diffs <- (agged.obs - array(gcm, dim(agged.obs))) ^ 2
-    diffs <- apply(diffs, 3, sum, na.rm=T)
-
+    diffs <- array(dim=c(dim(agged.obs))[3])
+    for(day in 1:dim(agged.obs)[3]) {
+      distances <- (agged.obs[,,day] - gcm) ^ 2
+      diffs[day] <- sum(distances, na.rm=T)
+    }
+    
     # Then find the 30 lowest differences
     # returns the indices for the n closest analogues
     # of this particular GCM timestep

--- a/R/CA.R
+++ b/R/CA.R
@@ -214,12 +214,12 @@ find.analogues <- function(gcm, agged.obs, times, now, n.analogues=getOption('n.
     # (obs years * (delta days * 2 + 1)) x cells
     # substract the GCM at this time step from the aggregated obs *for every library time value*
     # square that difference
-
-    diffs <- array(dim=c(dim(agged.obs))[3])
-    for(day in 1:dim(agged.obs)[3]) {
-      distances <- (agged.obs[,,day] - gcm) ^ 2
-      diffs[day] <- sum(distances, na.rm=T)
+    
+    find.daily.distance <- function(day) {
+      distances <- (agged.obs[,,day] - gcm) ^2
+      sum(distances, na.rm=T)
     }
+    diffs <- sapply(seq_along(ti), find.daily.distance)
     
     # Then find the 30 lowest differences
     # returns the indices for the n closest analogues


### PR DESCRIPTION
The Climate Analogues process calculates the difference between each day in the GCM output and each day in the observation dataset in order to find the 30 days in the observation dataset which are most similar to each day in the GCM dataset. 

Currently the algorithm:

1. aggregates the observation dataset and crops the gcm dataset so they have the same spatial extent and resolution
2. iterates over each day in the gcm dataset:
    - creates an array the same size as the observation dataset, but each day is the gcm day
    - subtracts the observation dataset from the repeated gcm day array, square results, store them in a new array
    - sum the per cell differences for each day, store one value per day in a new array
    - sort the days by difference, select the 30 with the smallest difference

This algorithm requires the creation of two new arrays the same size as the observation dataset, one to use for subtracting the gcm day from all observation days at once, one to store the per-cell-per-day results. R is not great at memory management, and we can see that creating arrays takes up about 25% of the total time used by the CA process:

```
$by.total
                             total.time total.pct self.time self.pct
"ca.netcdf.wrapper"            56061.70    100.00      0.00     0.00
"doTryCatch"                   54164.84     96.62      2.60     0.00
"tryCatch"                     54164.84     96.62      1.02     0.00
"tryCatchList"                 54164.84     96.62      0.36     0.00
"tryCatchOne"                  54164.84     96.62      0.32     0.00
"find.all.analogues"           54164.66     96.62      0.02     0.00
"%dopar%"                      54164.64     96.62      0.00     0.00
"e$fun"                        54164.64     96.62      0.00     0.00
"eval"                         54142.74     96.58      2.60     0.00
"find.analogues"               54138.22     96.57  19074.64    34.02
"apply"                        27645.26     49.31    354.90     0.63
"array"                        15014.28     26.78  14990.32    26.74
```

This PR switches to a faster but less elegant algorithm. It avoids creating the two large arrays by iterating over the observation dataset and creating arrays for individual days instead of processing it all at once:

1. aggregates the observation dataset and crops the gcm dataset so they have the same spatial extent and resolution
2. iterates over each day in the gcm dataset:
    - create an array with one slot for each day in the observation dataset
    - iterates over each day in the observation dataset
        - subtracts the gcm day from the observation day, store the results in a new single-day array
        - sum the per cell differences for the single-day array, store array in the one-slot-per-obs-day dataset
    - sort the days by difference, select the 30 with the smallest difference

Skipping the creation of the two large arrays makes the Climate Analogues runtime 20-30% faster.  
![all_size_for_loop](https://user-images.githubusercontent.com/4512605/100675340-a0369f80-331b-11eb-9656-8b0301766eed.png)
