### PR TITLE
Fix deprecated docType, tests and S3 method warning

### DIFF
--- a/R/CA.R
+++ b/R/CA.R
@@ -6,7 +6,7 @@
 # Input is a factor of which maps fine-scale obs cells to large-scale gcm cells
 # The factor should be of length x * y
 # and a 3d array of obs (x, y, time)
-aggregate.obs <- function(cell.factor, obs) {
+aggregate_obs <- function(cell.factor, obs) {
   trim <- getOption('trimmed.mean')
   apply(obs, 3, function(x) tapply(x, cell.factor, mean, trim=trim, na.rm=TRUE))
 }
@@ -14,12 +14,12 @@ aggregate.obs <- function(cell.factor, obs) {
 # Input cell indicies mapping obs grid to GCM grid
 # and a 3d array of obs (x, y, time)
 # Output is 3d array, gcmx x gcm y x time
-aggregate.obs.to.gcm.grid <- function(xi, yi, xn, yn, obs) {
+aggregate_obs_to_gcm_grid <- function(xi, yi, xn, yn, obs) {
   cell.number <- xi * max(yi) + yi
   cell.factor <- factor(cell.number, unique(as.vector(cell.number)))
   # apply preserving time (dim 3)
   # so for each time step, aggregate (take the mean) according to the cell map
-  rv <- aggregate.obs(cell.factor, obs)
+  rv <- aggregate_obs(cell.factor, obs)
   ti <- dim(obs)[3]
   dim(rv) <- c(xn, yn, ti)
   return(rv)
@@ -56,7 +56,7 @@ create.aggregates <- function(obs.file, gcm.file, varid) {
     print(paste("Aggregating timesteps", i['start'], "-", i['stop'], "/", length(obs.time)))
     obs <- CD_ncvar_get(nc.obs, varid=varid, start=c(1, 1, i['start']), # get obs for one chunk
                      count=c(-1, -1, i['length']))
-    agg <- aggregate.obs.to.gcm.grid(xi, yi, xn, yn, obs)
+    agg <- aggregate_obs_to_gcm_grid(xi, yi, xn, yn, obs)
     aggregates[min(xi):max(xi), min(yi):max(yi), i['start']:i['stop']] <- agg
     rm(obs)
     gc()

--- a/R/ClimDown.R
+++ b/R/ClimDown.R
@@ -17,12 +17,10 @@
 #' with Rscript.
 #'
 #' @name ClimDown
-#' @aliases ClimDown-package
-#' @docType package
 #' @references Werner, A. T., & Cannon, A. J. (2016). Hydrologic extremes  - an intercomparison of multiple gridded statistical downscaling methods. Hydrology and Earth System Sciences, 20(4), 1483-1508. doi: 10.5194/hess-20-1483-2016
 #' @keywords climate downscaling
 #' @import PCICt udunits2 ncdf4 fields foreach seas abind stats
-NULL
+"_PACKAGE"
 
 #' @title User-configurable options
 #'
@@ -111,9 +109,10 @@ NULL
 #' @examples
 #' \dontrun{
 #' library(doParallel)
-#' registerDoParallel(cores=4)
+#' registerDoParallel(cores = 4)
 #' bccaq.netcdf.wrapper(...)
-#' stopImplicitCluster()}
+#' stopImplicitCluster()
+#' }
 #'
 #' @seealso \pkg{doParallel} and \pkg{doMPI}
 #' @name parallelization

--- a/tests/test_bccaq.R
+++ b/tests/test_bccaq.R
@@ -3,6 +3,8 @@
 test.bccaq <- function() {
     out.nc <- tempfile(fileext='.nc')
     options(
+        gcm.varname="tasmax",
+        obs.varname="tasmax",
         calibration.end=as.POSIXct('1972-12-31', tz='GMT'),
         cend=as.POSIXct('1972-12-31', tz='GMT')
     )

--- a/tests/test_qdm.R
+++ b/tests/test_qdm.R
@@ -1,6 +1,6 @@
 .setUp <- function() {
     ci.file <<- tempfile(fileext='.nc')
-    ClimDown::ci.netcdf.wrapper('./tiny_gcm.nc', './tiny_obs.nc', ci.file, 'tasmax')
+    ClimDown::ci.netcdf.wrapper('./tiny_gcm.nc', './tiny_obs.nc', ci.file)
 }
 
 .tearDown <- function() {
@@ -10,6 +10,8 @@
 test.qdm <- function() {
     out.nc <- tempfile(fileext='.nc')
     options(
+        gcm.varname       = "tasmax",
+        obs.varname       = "tasmax",
         calibration.end=as.POSIXct('1972-12-31', tz='GMT'),
         cend=as.POSIXct('1972-12-31', tz='GMT')
     )

--- a/tests/test_rerank.R
+++ b/tests/test_rerank.R
@@ -1,9 +1,11 @@
 .setUp <- function() {
     options(
+        gcm.varname="tasmax",
+        obs.varname="tasmax",
         calibration.end=as.POSIXct('1972-12-31', tz='GMT')
     )
     ci.file <- tempfile(fileext='.nc')
-    ClimDown::ci.netcdf.wrapper('./tiny_gcm.nc', './tiny_obs.nc', ci.file, 'tasmax')
+    ClimDown::ci.netcdf.wrapper('./tiny_gcm.nc', './tiny_obs.nc', ci.file)
     qdm.file <<- tempfile(fileext='.nc')
     ClimDown::qdm.netcdf.wrapper('./tiny_obs.nc', ci.file, qdm.file, 'tasmax')
     unlink(ci.file)


### PR DESCRIPTION
### 1. Addressed Deprecation

**Replaces deprecated:**
```
#' @aliases ClimDown-package
#' @docType package
...
NULL
```
**With:**
`"_PACKAGE"`

### 2. Fixed Note:
```
checking S3 generic/method consistency ... 
NOTE Mismatches for apparent methods not registered: aggregate: function(x, ...) 
aggregate.obs.to.gcm.grid: function(xi, yi, xn, yn, obs)
```
Sets options `gcm.varname` and `obs.varname` used in tests

### Remaining Warnings
`R CMD Check --as-cran` completes with only one:
```
❯ checking package dependencies ... WARNING
  Requires orphaned package: ‘udunits2’
  ```